### PR TITLE
Debug github pages 404 error

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+      - run: npm ci
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Build site
+        env:
+          # For project pages (repo != <owner>.github.io), assets should live under /<repo>.
+          # If your repo is a user/org pages repo or you use a custom domain, this will still default to '/'.
+          ASTRO_BASE: ${{ endsWith(github.event.repository.name, '.github.io') && '/' || format('/{0}/', github.event.repository.name) }}
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/web/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -4,5 +4,6 @@ import tailwind from "@astrojs/tailwind";
 /** SSR optional later via adapters; dev uses preview server */
 export default {
   integrations: [tailwind({ applyBaseStyles: true })],
-  server: { host: true }
+  server: { host: true },
+  base: process.env.ASTRO_BASE ?? "/"
 };


### PR DESCRIPTION
Add GitHub Pages deployment workflow and configure Astro base path to resolve 404 error.

The site was returning a 404 because the existing CI only built the Astro app but did not deploy it to GitHub Pages. This PR adds the necessary workflow to deploy the built site and configures Astro to correctly handle base paths for GitHub Pages deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-d001365a-b979-4a7d-be4c-63927db91e84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d001365a-b979-4a7d-be4c-63927db91e84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

